### PR TITLE
fix(DATEV export): change format for column "Fälligkeit" to `%d%m%Y`

### DIFF
--- a/erpnext_datev/utils/datev_csv.py
+++ b/erpnext_datev/utils/datev_csv.py
@@ -34,7 +34,7 @@ def get_datev_csv(data, filters, csv_class):
 		result['Beleginfo - Inhalt 6'] = result['Beleginfo - Inhalt 6'].dt.strftime('%d%m%Y')
 
 		result['Fälligkeit'] = pd.to_datetime(result['Fälligkeit'])
-		result['Fälligkeit'] = result['Fälligkeit'].dt.strftime('%d%m%y')
+		result['Fälligkeit'] = result['Fälligkeit'].dt.strftime('%d%m%Y')
 
 		result.sort_values(by='Belegdatum', inplace=True, kind='stable', ignore_index=True)
 


### PR DESCRIPTION
Hi Raffael :),

ich habe eine kleine Änderung gemacht die das Format des "Fälligkeit" Feldes umändert auf ddmmjjjj, so wie es von Datev gewünscht ist.

Hier die DATEV Doku
https://developer.datev.de/datev/platform/de/dtvf/formate/buchungsstapel
![image](https://github.com/alyf-de/erpnext_datev/assets/118364772/a6789683-cfb1-4e38-9ff1-99cd7caae35a)

Würde mich sehr freuen wenn du diese Änderungen akzeptieren würdest.

Bei Fragen kannst du mir gerne schreiben.

Beste Grüße
Dietmar

