### PR TITLE
fix: round amounts in CSV export to 2 decimals

### DIFF
--- a/erpnext_datev/erpnext_datev/report/datev/datev.py
+++ b/erpnext_datev/erpnext_datev/report/datev/datev.py
@@ -349,10 +349,10 @@ def run_query(filters, extra_fields, extra_joins, extra_filters, as_dict=1):
 		SELECT
 
 			/* either debit or credit amount; always positive */
-			case gl.debit when 0 then gl.credit else gl.debit end as 'Umsatz (ohne Soll/Haben-Kz)',
+			case ROUND(gl.debit, 2) when 0 then ROUND(gl.credit, 2) else ROUND(gl.debit, 2) end as 'Umsatz (ohne Soll/Haben-Kz)',
 
 			/* 'H' when credit, 'S' when debit */
-			case gl.debit when 0 then 'H' else 'S' end as 'Soll/Haben-Kennzeichen',
+			case ROUND(gl.debit, 2) when 0 then 'H' else 'S' end as 'Soll/Haben-Kennzeichen',
 
 			/* account number or, if empty, party account number */
 			acc.account_number as 'Konto',


### PR DESCRIPTION
Hallo Raffael :),

wir haben einen kleinen Sonderfall entdeckt, der dafür sorgt, dass DATEV einen Export nicht annehmen könnte.

Undzwar.: Wenn das System zum Beispiel mal auf 9 stellige Dezimalgenauigkeit gesetzt war, dann werden die Werte Datenbankseitig von ERPNext auch auf 9-stelliger Genauigkeit gespeichert. Dabei ist dann auch egal ob man das System wieder auf 2-stellig setzt.

Die aktuelle Datev-Schnittstelle nimmt sich dann die Werte Datenbankseitig und exportiert diese dann auch 9-stellig. An sich auch kein Fehler, die Schnittstelle macht einfach nur das was sie soll. Nur ist seitens DATEV alles über 2-stellig leider ungültig. 

Aus diesem Grund habe ich in dieser Pull request in der zuständigen Query eine Round Funktion eingesetzt, welche immer auf zweistellig rundet. Damit sollte es dann seitens Datev keine Probleme mehr geben. :)!

![image](https://github.com/alyf-de/erpnext_datev/assets/118364772/dfa66e19-9e58-408b-ae73-7555a09723e1)


Ich würde mich sehr freuen wenn Du meine Pull Request annehmen würdest und solltest Du Fragen haben, kannst du dich wie immer gerne bei mir melden! Dürfte ich Dich dann evtl. auch noch bitten die Änderung gleich auf die unteren Versionen backzuporten?


Beste Grüße
Dietmar


