### PR TITLE
fix: temporary against account

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,16 @@ Integration between [ERPNext](https://github.com/frappe/erpnext) and DATEV.
 
 1. Datev Settings
 
-    Configure you client number, you tax consultant's number and a temporary against account.
+    Configure you client number, you tax consultant's number and a temporary against account. We recommend keeping the default against account "9090" as described in the [DATEV Help Center](https://apps.datev.de/help-center/documents/1002764).
 
 2. DATEV Report
 
     Now you can use the report "DATEV". This is a preview of the transactions data. It can be exported, along with the master data, as zip file via the report's menu. Your tax xonsultant can then import your GL Entries into his DATEV system.
+
+> [!IMPORTANT]
+> ERPNext does not have automatic VAT deduction ("Automatikkonten") on the GL Entry level. By using the default against account "9090", the automation is disabled.
+> 
+> If you use a different against account, please ensure to only book to non-automatic accounts in ERPNext. Otherwise, the VAT deduction will be incorrect.
 
 ## Setup DATEV Unternehmen Online [en]
 

--- a/erpnext_datev/erpnext_datev/doctype/datev_settings/datev_settings.json
+++ b/erpnext_datev/erpnext_datev/doctype/datev_settings/datev_settings.json
@@ -71,7 +71,7 @@
   },
   {
    "allow_in_quick_entry": 1,
-   "default": "9999",
+   "default": "9090",
    "description": "Will be used as against account for all normal ledger entries",
    "fieldname": "temporary_against_account_number",
    "fieldtype": "Data",
@@ -86,8 +86,9 @@
    "label": "Opening Against Account Number"
   }
  ],
+ "grid_page_length": 50,
  "links": [],
- "modified": "2023-06-29 18:00:12.981676",
+ "modified": "2025-06-12 16:30:22.776994",
  "modified_by": "Administrator",
  "module": "Erpnext Datev",
  "name": "DATEV Settings",
@@ -130,6 +131,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext_datev/erpnext_datev/report/datev/datev.py
+++ b/erpnext_datev/erpnext_datev/report/datev/datev.py
@@ -343,7 +343,7 @@ def run_query(filters, extra_fields, extra_joins, extra_filters, as_dict=1):
 			CASE gl.is_opening when 'Yes' then %(opening_account)s else %(against_account)s end as 'Gegenkonto (ohne BU-Schlüssel)',
 
 			/* disable automatic VAT deduction */
-			'40' as 'BU-Schlüssel',
+			'' as 'BU-Schlüssel',
 
 			gl.posting_date as 'Belegdatum',
 			gl.voucher_no as 'Belegfeld 1',


### PR DESCRIPTION
This pull request introduces updates to the DATEV CSV export, focusing on improving configuration defaults, enhancing documentation, and refining report behavior.

* Updated the configuration instructions to recommend using the default against account "9090" and added a note explaining the implications of using automatic VAT deduction. This improves clarity for users configuring DATEV integration.
* Changed the default value for the temporary against account number from "9999" to "9090" to align with DATEV recommendations.
* Changes the "BU-Schlüssel" field from "40" to _empty_ in the DATEV report, avoiding disabling the automation twice or for non-automatic accounts, which could lead to validation errors.