### PR TITLE
fix(DATEV): check company permission before export

### DIFF
--- a/erpnext_datev/erpnext_datev/report/datev/datev.py
+++ b/erpnext_datev/erpnext_datev/report/datev/datev.py
@@ -559,6 +559,8 @@ def download_datev_csv(filters):
 
 	validate(filters)
 
+	frappe.has_permission("Company", doc=filters.get("company"), throw=True)
+
 	company = filters.get("company")
 	fiscal_year = get_fiscal_year(date=filters.get("from_date"), company=company)
 	coa = frappe.get_value("Company", company, "chart_of_accounts")


### PR DESCRIPTION
The download was gated only by a role check, so any user with the Accounts User role could export the General Ledger of any company on the site. Verify read permission on the selected Company, including User Permissions.