### PR TITLE
feat(DATEV): filter voucher emails by document fields

### DIFF
--- a/erpnext_datev/erpnext_datev/doctype/datev_unternehmen_online_settings/datev_unternehmen_online_settings.js
+++ b/erpnext_datev/erpnext_datev/doctype/datev_unternehmen_online_settings/datev_unternehmen_online_settings.js
@@ -20,4 +20,51 @@ frappe.ui.form.on("DATEV Unternehmen Online Settings", {
 			};
 		});
 	},
+	datev_voucher_config_on_form_rendered(frm) {
+		const row = frm.cur_grid.doc;
+		const parent = frm.cur_grid.wrapper.find("[data-fieldname='filter_area']");
+		parent.empty();
+
+		if (!row.voucher_type) {
+			return;
+		}
+
+		const filters = row.filters && row.filters !== "[]" ? JSON.parse(row.filters) : [];
+
+		frappe.model.with_doctype(row.voucher_type, () => {
+			const filter_group = new frappe.ui.FilterGroup({
+				parent: parent,
+				doctype: row.voucher_type,
+				on_change: () => {
+					frappe.model.set_value(
+						row.doctype,
+						row.name,
+						"filters",
+						JSON.stringify(filter_group.get_filters())
+					);
+				},
+			});
+
+			filter_group.add_filters_to_filter_group(filters);
+		});
+	},
+});
+
+frappe.ui.form.on("DATEV Voucher Config", {
+	voucher_type(frm, cdt, cdn) {
+		const row = locals[cdt][cdn];
+		frappe.model.set_value(row.doctype, row.name, "filters", "[]");
+
+		if (row.print_format) {
+			frappe.db.get_value("Print Format", row.print_format, "doc_type").then((r) => {
+				if (r.message.doc_type !== row.voucher_type) {
+					frappe.model.set_value(row.doctype, row.name, "print_format", "");
+				}
+			});
+		}
+
+		if (frm.cur_grid) {
+			frm.events.datev_voucher_config_on_form_rendered(frm);
+		}
+	},
 });

--- a/erpnext_datev/erpnext_datev/doctype/datev_unternehmen_online_settings/datev_unternehmen_online_settings.py
+++ b/erpnext_datev/erpnext_datev/doctype/datev_unternehmen_online_settings/datev_unternehmen_online_settings.py
@@ -1,11 +1,14 @@
 # Copyright (c) 2021, ALYF GmbH and contributors
 # For license information, please see license.txt
 
+import json
+
 import frappe
 from frappe import _
 from frappe.core.doctype.communication.email import make as make_communication
 from frappe.model.document import Document
 from frappe.translate import print_language
+from frappe.utils.data import evaluate_filters
 
 
 class DATEVUnternehmenOnlineSettings(Document):
@@ -15,8 +18,11 @@ class DATEVUnternehmenOnlineSettings(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
-		from erpnext_datev.erpnext_datev.doctype.datev_voucher_config.datev_voucher_config import DATEVVoucherConfig
 		from frappe.types import DF
+
+		from erpnext_datev.erpnext_datev.doctype.datev_voucher_config.datev_voucher_config import (
+			DATEVVoucherConfig,
+		)
 
 		datev_voucher_config: DF.Table[DATEVVoucherConfig]
 		default_print_language: DF.Link | None
@@ -33,13 +39,23 @@ class DATEVUnternehmenOnlineSettings(Document):
 					)
 				)
 
+			try:
+				voucher_config.validate_filters()
+			except Exception as e:
+				frappe.clear_messages()
+				frappe.throw(
+					_("Row #{0}: invalid filters for <b>{1}</b>: {2}").format(
+						voucher_config.idx, _(voucher_config.voucher_type), e
+					)
+				)
+
 
 def send(doc, method):
 	settings = frappe.get_single("DATEV Unternehmen Online Settings")
 	if not settings.enabled:
 		return
 
-	voucher_config = get_voucher_config(settings, doc.doctype)
+	voucher_config = get_voucher_config(settings, doc)
 	if not voucher_config:
 		return
 
@@ -104,12 +120,14 @@ def attach_print(doctype, name, language, print_format):
 	return file.name
 
 
-def get_voucher_config(settings: DATEVUnternehmenOnlineSettings, doctype: str):
-	voucher_config = settings.get("datev_voucher_config", filters={"voucher_type": doctype})
-	if not voucher_config:
-		return
-
-	return voucher_config[0]
+def get_voucher_config(settings: DATEVUnternehmenOnlineSettings, doc):
+	"""Return the first voucher config for this DocType whose filters match the document."""
+	for voucher_config in settings.get("datev_voucher_config", filters={"voucher_type": doc.doctype}):
+		if voucher_config.filters:
+			filters = json.loads(voucher_config.filters)
+			if filters and not evaluate_filters(doc, filters):
+				continue
+		return voucher_config
 
 
 def get_attached_files(doctype: str, docname: str):

--- a/erpnext_datev/erpnext_datev/doctype/datev_unternehmen_online_settings/test_datev_unternehmen_online_settings.py
+++ b/erpnext_datev/erpnext_datev/doctype/datev_unternehmen_online_settings/test_datev_unternehmen_online_settings.py
@@ -1,9 +1,35 @@
 # Copyright (c) 2021, Alyf and Contributors
 # See license.txt
 
-# import frappe
-import unittest
+import json
+from unittest import TestCase
+
+import frappe
+
+from erpnext_datev.erpnext_datev.doctype.datev_unternehmen_online_settings.datev_unternehmen_online_settings import (
+	get_voucher_config,
+)
 
 
-class TestDATEVUnternehmenOnlineSettings(unittest.TestCase):
-	pass
+class TestDATEVUnternehmenOnlineSettings(TestCase):
+	def test_get_voucher_config_respects_filters(self):
+		settings = frappe.new_doc("DATEV Unternehmen Online Settings")
+		row = settings.append(
+			"datev_voucher_config",
+			{
+				"voucher_type": "Sales Invoice",
+				"recipient": "datev@example.com",
+				"attach_print": 1,
+				"print_format": "Standard",
+				"filters": json.dumps([["Sales Invoice", "status", "=", "Paid"]]),
+			},
+		)
+
+		paid = frappe._dict(doctype="Sales Invoice", status="Paid", name="SI-PAID")
+		unpaid = frappe._dict(doctype="Sales Invoice", status="Unpaid", name="SI-UNPAID")
+
+		self.assertEqual(get_voucher_config(settings, paid), row)
+		self.assertIsNone(get_voucher_config(settings, unpaid))
+
+		row.filters = "[]"
+		self.assertEqual(get_voucher_config(settings, unpaid), row)

--- a/erpnext_datev/erpnext_datev/doctype/datev_voucher_config/datev_voucher_config.json
+++ b/erpnext_datev/erpnext_datev/doctype/datev_voucher_config/datev_voucher_config.json
@@ -10,7 +10,11 @@
   "recipient",
   "attach_print",
   "print_format",
-  "attach_files"
+  "attach_files",
+  "section_break_filters",
+  "filter_description",
+  "filter_area",
+  "filters"
  ],
  "fields": [
   {
@@ -56,12 +60,35 @@
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Attach Files"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_break_filters",
+   "fieldtype": "Section Break",
+   "label": "Filters"
+  },
+  {
+   "fieldname": "filter_description",
+   "fieldtype": "HTML",
+   "options": "Optional: send email only if the submitted document matches these filters.<br><br>"
+  },
+  {
+   "fieldname": "filter_area",
+   "fieldtype": "HTML"
+  },
+  {
+   "fieldname": "filters",
+   "fieldtype": "Code",
+   "hidden": 1,
+   "label": "Filters",
+   "options": "JSON",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "istable": 1,
  "links": [],
- "modified": "2026-07-27 23:03:39.016538",
+ "modified": "2026-08-04 19:22:44.138497",
  "modified_by": "Administrator",
  "module": "Erpnext Datev",
  "name": "DATEV Voucher Config",

--- a/erpnext_datev/erpnext_datev/doctype/datev_voucher_config/datev_voucher_config.py
+++ b/erpnext_datev/erpnext_datev/doctype/datev_voucher_config/datev_voucher_config.py
@@ -1,8 +1,11 @@
 # Copyright (c) 2021, Alyf and contributors
 # For license information, please see license.txt
 
-# import frappe
+import json
+
+import frappe
 from frappe.model.document import Document
+from frappe.utils.data import evaluate_filters
 
 
 class DATEVVoucherConfig(Document):
@@ -16,6 +19,7 @@ class DATEVVoucherConfig(Document):
 
 		attach_files: DF.Check
 		attach_print: DF.Check
+		filters: DF.Code | None
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
@@ -24,4 +28,10 @@ class DATEVVoucherConfig(Document):
 		voucher_type: DF.Link
 	# end: auto-generated types
 
-	pass
+	def validate_filters(self):
+		if not self.filters:
+			return
+
+		filters = json.loads(self.filters)
+		dummy_doc = frappe.new_doc(self.voucher_type)
+		evaluate_filters(dummy_doc, filters)


### PR DESCRIPTION
## Summary
- Add optional filters to each DATEV voucher configuration row.
- Send voucher emails only when submitted documents match the configured filters.
- Validate saved filters and cover matching behavior with a focused test.

## Test plan
- [x] Run the DATEV Unternehmen Online Settings filter test.
- [x] Verify matching, nonmatching, and empty filter behavior.